### PR TITLE
mockCaptchaApi에서 captchaApi로 실제 백엔드 연동으로 전환

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,11 +3,20 @@ import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
+import reactX from 'eslint-plugin-react-x'
+import reactDom from 'eslint-plugin-react-dom'
 
 export default tseslint.config(
   { ignores: ['dist'] },
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    extends: [
+      // Remove ...tseslint.configs.recommended and replace with this
+      ...tseslint.configs.recommendedTypeChecked,
+      // Alternatively, use this for stricter rules
+      ...tseslint.configs.strictTypeChecked,
+      // Optionally, add this for stylistic rules
+      ...tseslint.configs.stylisticTypeChecked,
+    ],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,
@@ -16,6 +25,8 @@ export default tseslint.config(
     plugins: {
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
+      'react-x': reactX,
+      'react-dom': reactDom,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
@@ -24,6 +35,12 @@ export default tseslint.config(
         { allowConstantExport: true },
       ],
       '@typescript-eslint/no-unused-vars': 'off',
+      ...reactX.configs['recommended-typescript'].rules,
+      ...reactDom.configs.recommended.rules,
+    },
+    parserOptions: {
+      project: ['./tsconfig.node.json', './tsconfig.app.json'],
+      tsconfigRootDir: import.meta.dirname,
     },
   },
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "doez-fe",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.8.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -1733,6 +1734,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1795,6 +1813,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -1905,6 +1936,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
@@ -1976,6 +2019,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.123",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.123.tgz",
@@ -2001,6 +2067,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -2401,6 +2512,41 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2414,6 +2560,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gensync": {
@@ -2437,6 +2592,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -2478,6 +2670,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2493,6 +2697,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/human-signals": {
@@ -2886,6 +3129,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2915,6 +3167,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -3211,6 +3484,12 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "prepare": "husky install", 
+    "prepare": "husky install",
     "lint-staged": "lint-staged"
   },
   "dependencies": {
+    "axios": "^1.8.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -31,9 +32,8 @@
     "typescript-eslint": "^8.24.1",
     "vite": "^6.2.0"
   },
-  "lint-staged": {  
-    "**/*.{js,jsx,ts,tsx,json,css,md}": "prettier --write", 
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx,json,css,md}": "prettier --write",
     "**/*.{js,jsx,ts,tsx}": "eslint --fix"
-  }  
-  
+  }
 }

--- a/src/api/captchaApi.ts
+++ b/src/api/captchaApi.ts
@@ -1,28 +1,39 @@
+// src/api/captchaApi.ts
+import axios from 'axios';
+
 export interface CaptchaChallenge {
-    id: string;
-    expected: string;
-  }
-  
-  export interface PredictResponse {
-    passed: boolean;
-    message?: string;
-  }
-  
-  export async function fetchCaptchaChallenge(): Promise<CaptchaChallenge> {
-    const res = await fetch("http://localhost:8000/captcha");
-    if (!res.ok) throw new Error("캡차 로딩 실패");
-    return await res.json();
-  }
-  
-  export async function submitCaptchaImage(imageBase64: string, id: string): Promise<PredictResponse> {
-    const res = await fetch("http://localhost:8000/predict", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({ image: imageBase64, id })
-    });
-    if (!res.ok) throw new Error("제출 실패");
-    return await res.json();
-  }
-  
+  id: string;
+  expected: string;
+}
+
+export interface PredictResponse {
+  passed: boolean;
+  message: string;
+}
+
+const BASE_URL = 'http://localhost:8000'; // 백엔드 주소
+
+export async function fetchCaptchaChallenge(): Promise<CaptchaChallenge> {
+  const res = await axios.get(`${BASE_URL}/captcha`, {
+    withCredentials: true,
+  });
+  return await res.data;
+}
+
+export async function submitCaptchaImage(
+  imageBase64: string,
+  id: string
+): Promise<PredictResponse> {
+  const res = await axios.post(
+    `${BASE_URL}/predict`,
+    {
+      image: imageBase64,
+      id: id,
+    },
+    {
+      withCredentials: true,
+    }
+  );
+
+  return await res.data;
+}

--- a/src/api/mockCaptchaApi.ts
+++ b/src/api/mockCaptchaApi.ts
@@ -1,40 +1,48 @@
 // src/api/captchaApi.ts
 
 export interface CaptchaChallenge {
-    id: string;
-    expected: string;
-  }
-  
-  export interface PredictResponse {
-    passed: boolean;
-    message?: string;
-  }
-  
-  // ✅ mock challenge ID & expected 값 저장 (임의로 고정)
-  let currentMockCaptcha: CaptchaChallenge = {
-    id: "mock-123",
-    expected: Math.floor(Math.random() * 10).toString() // 0~9 중 하나
+  id: string;
+  expected: string;
+}
+
+export interface PredictResponse {
+  passed: boolean;
+  message?: string;
+}
+
+// ✅ mock challenge ID & expected 값 저장 (임의로 고정)
+let currentMockCaptcha: CaptchaChallenge = {
+  id: 'mock-123',
+  expected: Math.floor(Math.random() * 10).toString(), // 0~9 중 하나
+};
+
+export async function fetchCaptchaChallenge(): Promise<CaptchaChallenge> {
+  // 시뮬레이션: 서버에서 새로운 캡차 받음
+  currentMockCaptcha = {
+    id: 'mock-123',
+    expected: Math.floor(Math.random() * 10).toString(),
   };
-  
-  export async function fetchCaptchaChallenge(): Promise<CaptchaChallenge> {
-    // 시뮬레이션: 서버에서 새로운 캡차 받음
-    currentMockCaptcha = {
-      id: "mock-123",
-      expected: Math.floor(Math.random() * 10).toString()
-    };
-    console.log("[Mock] New captcha:", currentMockCaptcha.expected);
-    return new Promise(resolve => setTimeout(() => resolve(currentMockCaptcha), 300)); // simulate delay
-  }
-  
-  export async function submitCaptchaImage(imageBase64: string, id: string): Promise<PredictResponse> {
-    // 시뮬레이션: 랜덤으로 정답 or 오답 처리
-    const passed = Math.random() < 0.5;
-    console.log("[Mock] Captcha submitted:", { imageBase64, id });
-    return new Promise(resolve =>
-      setTimeout(() => resolve({
-        passed,
-        message: passed ? "통과!" : "실패!"
-      }), 500)
-    );
-  }
-  
+  console.log('[Mock] New captcha:', currentMockCaptcha.expected);
+  return new Promise((resolve) =>
+    setTimeout(() => resolve(currentMockCaptcha), 300)
+  ); // simulate delay
+}
+
+export async function submitCaptchaImage(
+  imageBase64: string,
+  id: string
+): Promise<PredictResponse> {
+  // 시뮬레이션: 랜덤으로 정답 or 오답 처리
+  const passed = Math.random() < 0.5;
+  console.log('[Mock] Captcha submitted:', { imageBase64, id });
+  return new Promise((resolve) =>
+    setTimeout(
+      () =>
+        resolve({
+          passed,
+          message: passed ? '통과!' : '실패!',
+        }),
+      500
+    )
+  );
+}

--- a/src/components/CaptchaCanvas.tsx
+++ b/src/components/CaptchaCanvas.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef, useState } from "react";
-import { fetchCaptchaChallenge, submitCaptchaImage } from "../api/mockCaptchaApi";
+import React, { useEffect, useRef, useState } from 'react';
+import { fetchCaptchaChallenge, submitCaptchaImage } from '../api/captchaApi';
 
 const CANVAS_WIDTH = 200;
 const CANVAS_HEIGHT = 200;
@@ -7,9 +7,9 @@ const CANVAS_HEIGHT = 200;
 const CaptchaCanvas: React.FC = () => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const isDrawing = useRef(false);
-  const [message, setMessage] = useState("");
-  const [captchaText, setCaptchaText] = useState<string>("");
-  const [captchaId, setCaptchaId] = useState<string>("");
+  const [message, setMessage] = useState('');
+  const [captchaText, setCaptchaText] = useState<string>('');
+  const [captchaId, setCaptchaId] = useState<string>('');
 
   const fetchChallenge = async () => {
     try {
@@ -17,9 +17,9 @@ const CaptchaCanvas: React.FC = () => {
       setCaptchaText(data.expected);
       setCaptchaId(data.id);
       clearCanvas();
-      setMessage("");
+      setMessage('');
     } catch {
-      setMessage("⚠️ 캡차 불러오기 실패");
+      setMessage('⚠️ 캡차 불러오기 실패');
     }
   };
 
@@ -29,29 +29,29 @@ const CaptchaCanvas: React.FC = () => {
 
   const clearCanvas = () => {
     const canvas = canvasRef.current;
-    const ctx = canvas?.getContext("2d");
+    const ctx = canvas?.getContext('2d');
     if (ctx && canvas) {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-      ctx.fillStyle = "#ffffff";
+      ctx.fillStyle = '#ffffff';
       ctx.fillRect(0, 0, canvas.width, canvas.height);
     }
   };
 
   const handleMouseDown = (e: React.MouseEvent) => {
     isDrawing.current = true;
-    const ctx = canvasRef.current?.getContext("2d");
+    const ctx = canvasRef.current?.getContext('2d');
     ctx?.beginPath();
     ctx?.moveTo(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
   };
 
   const handleMouseMove = (e: React.MouseEvent) => {
     if (!isDrawing.current) return;
-    const ctx = canvasRef.current?.getContext("2d");
+    const ctx = canvasRef.current?.getContext('2d');
     if (!ctx) return;
     ctx.lineTo(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
-    ctx.strokeStyle = "#000";
+    ctx.strokeStyle = '#000';
     ctx.lineWidth = 10;
-    ctx.lineCap = "round";
+    ctx.lineCap = 'round';
     ctx.stroke();
   };
 
@@ -63,23 +63,27 @@ const CaptchaCanvas: React.FC = () => {
     const canvas = canvasRef.current;
     if (!canvas || !captchaId) return;
 
-    const image = canvas.toDataURL("image/png");
+    const image = canvas.toDataURL('image/png');
 
     try {
       const res = await submitCaptchaImage(image, captchaId);
+      const msg = res.message;
+      console.log(res);
       if (res.passed) {
-        setMessage("캡차 통과!");
+        setMessage(msg);
       } else {
-        setMessage("틀렸어요! 다시 시도해주세요.");
-        await fetchChallenge(); // 실패 시 새로운 문제 불러오기
+        setMessage(msg);
+        setTimeout(async () => {
+          await fetchChallenge();
+        }, 1000); // 실패 시 새로운 문제 불러오기
       }
     } catch (err) {
-      setMessage("⚠️ 서버 오류");
+      setMessage('⚠️ 서버 오류');
     }
   };
 
   return (
-    <div style={{ textAlign: "center" }}>
+    <div style={{ textAlign: 'center' }}>
       <h3>아래에 "{captchaText}" 를 그려주세요</h3>
       <canvas
         ref={canvasRef}
@@ -88,15 +92,19 @@ const CaptchaCanvas: React.FC = () => {
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
-        style={{ background: "#fff", border: "1px solid #aaa", cursor: "crosshair" }}
+        style={{
+          background: '#fff',
+          border: '1px solid #aaa',
+          cursor: 'crosshair',
+        }}
       />
-      <div style={{ marginTop: "10px" }}>
-        <button onClick={handleSubmit} style={{ marginRight: "10px" }}>
+      <div style={{ marginTop: '10px' }}>
+        <button onClick={handleSubmit} style={{ marginRight: '10px' }}>
           제출
         </button>
         <button onClick={fetchChallenge}>새로고침</button>
       </div>
-      <p style={{ marginTop: "10px" }}>{message}</p>
+      <p style={{ marginTop: '10px' }}>{message}</p>
     </div>
   );
 };


### PR DESCRIPTION
- 테스트용 mockCaptchaApi 제거
- 실제 FastAPI 서버와 연동되는 captchaApi로 변경
- 프론트엔드에서 실시간 예측 결과를 받을 수 있도록 수정